### PR TITLE
Update panasonic-comfort-cloud-client to fix API issue

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "panasonic-comfort-cloud-client": "1.2.0"
+    "panasonic-comfort-cloud-client": "1.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.0.5",
+  "version": "1.1.1",
   "main": "app.ts",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Looks like @marc2016 has fixed the API issue that Panasonic introduced earlier this week: https://github.com/marc2016/panasonic-comfort-cloud-client/issues/13

Bumping the version of the library, plus the version of the app.