### PR TITLE
Override client package version to fix auth failure

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/drivers/aircon/driver.ts
+++ b/drivers/aircon/driver.ts
@@ -10,7 +10,7 @@ export class MyDriver extends Homey.Driver {
   async getClient() : Promise<ComfortCloudClient> {
     if (this.client === undefined)
     {
-      let appVersion = "1.19.0";
+      let appVersion = "1.20.0";
       this.log('initializing client ('+appVersion+')');
       this.client = new ComfortCloudClient(appVersion);
       let token:string = this.homey.settings.get("token");


### PR DESCRIPTION
I submitted a [PR](https://github.com/marc2016/panasonic-comfort-cloud-client/pull/15) to the client package, and then realised there's the option of explicitly setting a different X-APP value when initiating ComfortCloudClient. This PR sets the version explicitly (and bumps the homey app version).

Tested against my CS-HZ25XKE and it seems to be working again 👍 