### PR TITLE
Bump version ... again

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/drivers/aircon/driver.ts
+++ b/drivers/aircon/driver.ts
@@ -10,7 +10,7 @@ export class MyDriver extends Homey.Driver {
   async getClient() : Promise<ComfortCloudClient> {
     if (this.client === undefined)
     {
-      let appVersion = "1.20.0";
+      let appVersion = "1.20.1";
       this.log('initializing client ('+appVersion+')');
       this.client = new ComfortCloudClient(appVersion);
       let token:string = this.homey.settings.get("token");


### PR DESCRIPTION
The Panasonic server started throwing 401s again. I've checked the Comfort Cloud app version in the App store, and matched it in this update. Seems to be working again.