### PR TITLE
Fix power consumption calculation for OFF state

### DIFF
--- a/drivers/aircon/device.ts
+++ b/drivers/aircon/device.ts
@@ -53,6 +53,12 @@ export class MyDevice extends Homey.Device {
     if (!device)
       return;
 
+    // If the device is OFF, power consumption should be 0
+    if (device.operate !== Power.On) {
+      this.setCap('measure_power', 0);
+      return;
+    }
+
     // Get the timezone offset in the format "+01:00" with Europe/Oslo as default (Change this to some other default?)
     let timeZone = this.minutesToHours(this.getOffset(this.homey.clock.getTimezone() || 'Europe/Oslo')) || '+01:00';
 


### PR DESCRIPTION
## Summary
- Fix power consumption calculation to return 0 when device is in OFF state
- Prevent showing stale consumption data when the air conditioning unit is turned off

## Changes
- Added check for device OFF state in `fetchLastHourWattsConsumption()`
- Set `measure_power` to 0 and return early when device is not ON
- Clean implementation without debug logging

## Problem Solved
This addresses the issue where the device would report power consumption even when the AC was clearly in OFF state, showing misleading energy usage data.

## Testing
- Device correctly shows 0W power consumption when OFF
- Normal power readings continue when device is ON