### PR TITLE
Make sure action cards are registered only once in case of multiple devices

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/drivers/aircon/device.ts
+++ b/drivers/aircon/device.ts
@@ -233,7 +233,7 @@ export class MyDevice extends Homey.Device {
     changeEcoMode.registerRunListener(async (args) => {
       await this.postToService({ eco_mode: args.mode });
     });
-
+    this.log("device action cards have been initialized");
   }
 
   /**
@@ -268,7 +268,12 @@ export class MyDevice extends Homey.Device {
     }
 
     // TO BE DEPRECATED: Do not initialize action cards from the device (since devices::onInit is called for every device) but from drivers::onInit
-    await this.initActionCards();
+    await this.driver.actionCardsMutex.runExclusive(async () => {
+      if (this.driver.actionCardsInitiated === false) {
+        await this.initActionCards();
+        this.driver.actionCardsInitiated = true;
+      }
+    });
 
     const settings = this.getSettings();
     this.alwaysOn = settings.alwayson;

--- a/drivers/aircon/driver.ts
+++ b/drivers/aircon/driver.ts
@@ -14,6 +14,8 @@ export class MyDriver extends Homey.Driver {
   client: ComfortCloudClient | null | undefined = undefined;
   ignoreSettings:boolean=false;
   clientMutex:Mutex = new Mutex();
+  actionCardsInitiated: boolean = false;
+  actionCardsMutex:Mutex = new Mutex();
 
   // From https://github.com/Magnusri/homey-panasonic-comfort-cloud-alt/blob/master/drivers/aircon/driver.ts
   async getLatestAppVersion(): Promise<string> {
@@ -147,6 +149,7 @@ export class MyDriver extends Homey.Driver {
       changeOperationMode.registerRunListener(async (args) => {
         await args.device.postToService({ operation_mode: args.mode });
       });
+      this.log("driver action cards have been initialized");
     }
 
   /**


### PR DESCRIPTION
Action cards are wrongly initiated from the device class, but removing it will (I think) result in an unwanted breaking change. Make sure the action cards are at least initialized only once in setups with multiple devices to avoid error messages when the app is started.