### PR TITLE
Add setting per device for poll interval in seconds

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [
@@ -621,6 +621,21 @@
           "hint": {
             "en": "Keep device on.",
             "no": "Forhindre at Homey slår av denne enheten."
+          }
+        },
+        {
+          "id": "fetchinterval",
+          "type": "number",
+          "label": {
+            "en": "Poll interval (sec)",
+            "no": "Poll interval (sek)"
+          },
+          "value": 60,
+          "min": 60,
+          "max": 900,
+          "hint": {
+            "en": "Time (sec) between fetching device status.",
+            "no": "Tid (sek) mellom henting av device status."
           }
         }
       ]

--- a/drivers/aircon/driver.settings.compose.json
+++ b/drivers/aircon/driver.settings.compose.json
@@ -11,5 +11,20 @@
         "en": "Keep device on.",
         "no": "Forhindre at Homey slår av denne enheten."
       }
+    },
+    {
+      "id": "fetchinterval",
+      "type": "number",
+      "label": {
+        "en": "Poll interval (sec)",
+        "no": "Poll interval (sek)"
+        },
+      "value": 60,
+      "min": 60,
+      "max": 900,
+      "hint": {
+        "en": "Time (sec) between fetching device status.",
+        "no": "Tid (sek) mellom henting av device status."
+      }
     }
 ]


### PR DESCRIPTION
This change makes it possible to configure status fetch interval between 60 and 900 seconds in the "Advanced settings" section per device.

Original code pulls device status every 60sec, fixed, but this adds to quite a lot of traffic on the Panasonic API (from all Homey users) and per useraccounts when having many devices which may result in issues (remember we had issues some time back where accounts stopped working due to suspicious account activity?).
Also; who really needs update on device status, inside/outside temp+++ into Homey every minute 24/7/365? Yes, you do get a delay on Homey update if the device configuration is changed with remote og Comfort APP if fetch interval i set higher, but this seldom presents a problem.

For reference: I have configured a 10min (600 sec) interval for all my 4 devices.

I have run this code in my own setup (1 device at home + 3 devices as a public building) for a few months now without issues.