### PR TITLE
Switch back from thermostat_mode to operation_mode capability

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/.homeycompose/capabilities/operation_mode.json
+++ b/.homeycompose/capabilities/operation_mode.json
@@ -6,23 +6,23 @@
     "setable": true,
     "values": [
         {
-            "id": "auto",
+            "id": "Auto",
             "title": { "en": "Auto"}
         },
         {
-            "id": "dry",
+            "id": "Dry",
             "title": { "en": "Dry"}
         },
         {
-            "id": "cool",
+            "id": "Cool",
             "title": { "en": "Cool"}
         },
         {
-            "id": "heat",
+            "id": "Heat",
             "title": { "en": "Heat"}
         },
         {
-            "id": "fan",
+            "id": "Fan",
             "title": { "en": "Fan"}
         }
     ]

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.schmidt-cisternas.pcc-alt",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [
@@ -948,7 +948,7 @@
         }
       ]
     },
-    "thermostat_mode": {
+    "operation_mode": {
       "type": "enum",
       "title": {
         "en": "Operation Mode"
@@ -958,31 +958,31 @@
       "setable": true,
       "values": [
         {
-          "id": "auto",
+          "id": "Auto",
           "title": {
             "en": "Auto"
           }
         },
         {
-          "id": "dry",
+          "id": "Dry",
           "title": {
             "en": "Dry"
           }
         },
         {
-          "id": "cool",
+          "id": "Cool",
           "title": {
             "en": "Cool"
           }
         },
         {
-          "id": "heat",
+          "id": "Heat",
           "title": {
             "en": "Heat"
           }
         },
         {
-          "id": "fan",
+          "id": "Fan",
           "title": {
             "en": "Fan"
           }

--- a/drivers/aircon/device.ts
+++ b/drivers/aircon/device.ts
@@ -148,7 +148,7 @@ export class MyDevice extends Homey.Device {
     }
     await this.setCap('measure_temperature_outside', device.outTemperature);
     await this.setCap('target_temperature', device.temperatureSet);
-    await this.setCap('thermostat_mode', OperationMode[device.operationMode].toLowerCase());
+    await this.setCap('operation_mode', OperationMode[device.operationMode]);
     await this.setCap('eco_mode', EcoMode[device.ecoMode]);
     if (airSwingLR === undefined)
       this.log("failed to parse airSwingLR value '"+device.airSwingLR+"'");
@@ -187,8 +187,7 @@ export class MyDevice extends Homey.Device {
     let params : Parameters = { 
       operate: getParam(values['onoff'], v => v ? Power.On : Power.Off), 
       temperatureSet: values['target_temperature'],
-      // Uppercase first letter to match the enum values in ComfortCloudClient
-      operationMode: getParam(values['thermostat_mode'], v => OperationMode[v.charAt(0).toUpperCase() + v.slice(1)]),
+      operationMode: getParam(values['operation_mode'], v => OperationMode[v]),
       ecoMode: getParam(values['eco_mode'], v => EcoMode[v]),
       airSwingLR: getParam(values['air_swing_lr'], v => (AirSwingLR[v] as any) == 3 ? 5 : AirSwingLR[v]), // See comment in fetchFromService on AirSwingLR
       airSwingUD: getParam(values['air_swing_ud'], v => AirSwingUD[v]),
@@ -224,7 +223,7 @@ export class MyDevice extends Homey.Device {
 
     const changeOperationMode = this.homey.flow.getActionCard('change-operation-mode');
     changeOperationMode.registerRunListener(async (args) => {
-      await this.postToService({ thermostat_mode: args.mode });
+      await this.postToService({ operation_mode: args.mode });
     });
 
     const changeFanSpeed = this.homey.flow.getActionCard('change-fan-speed');
@@ -248,7 +247,7 @@ export class MyDevice extends Homey.Device {
       [
         'onoff',
         'target_temperature',
-        'thermostat_mode',
+        'operation_mode',
         'eco_mode',
         'air_swing_lr',
         'air_swing_ud',

--- a/drivers/aircon/driver.ts
+++ b/drivers/aircon/driver.ts
@@ -147,7 +147,7 @@ export class MyDriver extends Homey.Driver {
 
       const changeOperationMode = this.homey.flow.getActionCard('device-change-operation-mode');
       changeOperationMode.registerRunListener(async (args) => {
-        await args.device.postToService({ thermostat_mode: args.mode });
+        await args.device.postToService({ operation_mode: args.mode });
       });
       this.log("driver action cards have been initialized");
     }


### PR DESCRIPTION
Fixes #55 
We can't use built-in capability thermostat_mode in our app since it only support values automatic, heat, cool and off while our devices support auto, dry, cool, heat and fan. This PR changes back from using thermostat_mode to custom operation_mode capability (=reverts change from Aug 7th).
This patch does not fix the fact that changing thermostat_mode for a device in the Homey APP now triggers a 500 error since the code currently doesn't register thermostat_mode as a supported capability. 