### PR TITLE
Added operation mode 'and' flow card

### DIFF
--- a/.homeycompose/flow/conditions/operation-mode.json
+++ b/.homeycompose/flow/conditions/operation-mode.json
@@ -1,0 +1,29 @@
+{
+  "title": {
+    "en": "Operation mode is",
+    "no": "Driftsmodus er"
+  },
+  "titleFormatted": {
+    "en": "Operation mode !{{is|isn't}} [[mode]]",
+    "no": "Driftsmodus !{{er|er ikke}} [[mode]]"
+  },
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "driver_id=aircon"
+    },
+    {
+      "type": "dropdown",
+      "name": "mode",
+      "title": { "en": "Mode", "no": "Driftsmodus" },
+      "values": [
+        { "id": "Auto", "label": { "en": "Auto", "no": "Automatisk" } },
+        { "id": "Dry",  "label": { "en": "Dry",  "no": "Tørr" } },
+        { "id": "Cool", "label": { "en": "Cool", "no": "Kjøling" } },
+        { "id": "Heat", "label": { "en": "Heat", "no": "Varme" } },
+        { "id": "Fan",  "label": { "en": "Fan",  "no": "Vifte" } }
+      ]
+    }
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -34,6 +34,71 @@
     "url": "https://github.com/ugumba/homey-panasonic-comfort-cloud-alt/issues"
   },
   "flow": {
+    "conditions": [
+      {
+        "title": {
+          "en": "Operation mode is",
+          "no": "Driftsmodus er"
+        },
+        "titleFormatted": {
+          "en": "Operation mode !{{is|isn't}} [[mode]]",
+          "no": "Driftsmodus !{{er|er ikke}} [[mode]]"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=aircon"
+          },
+          {
+            "type": "dropdown",
+            "name": "mode",
+            "title": {
+              "en": "Mode",
+              "no": "Driftsmodus"
+            },
+            "values": [
+              {
+                "id": "Auto",
+                "label": {
+                  "en": "Auto",
+                  "no": "Automatisk"
+                }
+              },
+              {
+                "id": "Dry",
+                "label": {
+                  "en": "Dry",
+                  "no": "Tørr"
+                }
+              },
+              {
+                "id": "Cool",
+                "label": {
+                  "en": "Cool",
+                  "no": "Kjøling"
+                }
+              },
+              {
+                "id": "Heat",
+                "label": {
+                  "en": "Heat",
+                  "no": "Varme"
+                }
+              },
+              {
+                "id": "Fan",
+                "label": {
+                  "en": "Fan",
+                  "no": "Vifte"
+                }
+              }
+            ]
+          }
+        ],
+        "id": "operation-mode"
+      }
+    ],
     "actions": [
       {
         "title": {

--- a/app.ts
+++ b/app.ts
@@ -13,6 +13,12 @@ class MyApp extends Homey.App {
       this.homey.settings.set("log", this.logs.join(""));
     });
 
+    this.homey.flow.getConditionCard('operation-mode')
+      .registerRunListener(async (args) => {
+        const currentMode = args.device.getCapabilityValue('operation_mode');
+        return currentMode === args.mode;
+      });
+
     this.log('MyApp has been initialized');
   }
 


### PR DESCRIPTION
Created 'and' card (with help from Copilot in VS) for operation mode.
Fixes https://github.com/ugumba/homey-panasonic-comfort-cloud-alt/issues/46